### PR TITLE
Add explosion and delay before new ship offer

### DIFF
--- a/src/ecs/Component.ts
+++ b/src/ecs/Component.ts
@@ -296,6 +296,8 @@ export interface GameStateComponent extends Component {
     wave2EnemiesDefeated: number
     bossSpawned: boolean
     playerHits: number // Track hits taken by player for boss encounter
+    playerDeathStartTime?: number // When player death was detected (for delay before new ship offer)
+    playerDeathDelayDuration: number // How long to wait before showing new ship offer (seconds)
 }
 
 // Boss tag component for boss entities

--- a/src/systems/CollisionSystem.ts
+++ b/src/systems/CollisionSystem.ts
@@ -122,11 +122,8 @@ export class CollisionSystem extends System {
                         // Play death/explosion sound
                         this.playDeathSound()
 
-                        // Start death animation for enemies (not player)
-                        if (
-                            target.hasComponent('enemy') &&
-                            this.deathAnimationSystem
-                        ) {
+                        // Start death animation for enemies and players
+                        if (this.deathAnimationSystem) {
                             this.deathAnimationSystem.startDeathAnimation(
                                 target,
                             )


### PR DESCRIPTION
Add player death explosion particles and a 1-second delay before showing the new ship offer.

Previously, player death immediately transitioned to the new ship offer without any visual feedback or delay, unlike enemy destructions. This change aligns player death with enemy explosions and provides a moment for the player to observe the effects before the next screen appears.

---

[Open in Web](https://cursor.com/agents?id=bc-b18b24d1-b5f2-4a52-b057-20e82509f902) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-b18b24d1-b5f2-4a52-b057-20e82509f902)

Learn more about [Background Agents](https://docs.cursor.com/background-agent/web-and-mobile)