### PR TITLE
Prepare for boss encounter with preview state

### DIFF
--- a/src/ecs/Component.ts
+++ b/src/ecs/Component.ts
@@ -294,6 +294,7 @@ export type GameState =
     | 'initialWave'
     | 'enemiesWave1'
     | 'enemiesWave2'
+    | 'bossPreview'
     | 'bossFight'
     | 'newShipOffer'
 

--- a/src/systems/GameStateSystem.ts
+++ b/src/systems/GameStateSystem.ts
@@ -79,11 +79,12 @@ export class GameStateSystem extends System {
 
         // Handle current state using appropriate handler
         const stateHandler = this.stateHandlers.get(gameState.currentState)
-        if (stateHandler) {
+        if (stateHandler && this.gameWorld) {
             const nextState = stateHandler.handle(
                 gameState,
                 this.config,
                 this.world,
+                this.gameWorld,
             )
             if (nextState) {
                 gameState.currentState = nextState as GameState

--- a/src/systems/GameStateSystem.ts
+++ b/src/systems/GameStateSystem.ts
@@ -14,6 +14,7 @@ import type { GameWorld } from '../GameWorld'
 import type { GameStateHandler } from './states'
 import {
     BossFightState,
+    BossPreviewState,
     InitialWaveState,
     NewShipOfferState,
     Wave1State,
@@ -39,6 +40,7 @@ export class GameStateSystem extends System {
         this.stateHandlers.set('initialWave', new InitialWaveState())
         this.stateHandlers.set('enemiesWave1', new Wave1State())
         this.stateHandlers.set('enemiesWave2', new Wave2State())
+        this.stateHandlers.set('bossPreview', new BossPreviewState())
         this.stateHandlers.set('bossFight', new BossFightState())
         this.stateHandlers.set('newShipOffer', new NewShipOfferState())
     }
@@ -68,10 +70,11 @@ export class GameStateSystem extends System {
 
         if (
             gameTime >= this.config.boss.forceSpawnTimeSeconds &&
+            gameState.currentState !== 'bossPreview' &&
             gameState.currentState !== 'bossFight' &&
             gameState.currentState !== 'newShipOffer'
         ) {
-            gameState.currentState = 'bossFight'
+            gameState.currentState = 'bossPreview'
         }
 
         // Handle current state using appropriate handler

--- a/src/systems/states/BaseGameState.ts
+++ b/src/systems/states/BaseGameState.ts
@@ -15,13 +15,14 @@ export interface GameStateHandler {
      * @param gameState The current game state component
      * @param config Configuration for this state
      * @param world The ECS world
-     * @param levelingSystem Reference to the leveling system for XP awarding
+     * @param gameWorld The GameWorld instance for accessing camera and other systems
      * @returns Next state to transition to, or null to stay in current state
      */
     handle(
         gameState: GameStateComponent,
         config: GameStateConfig,
         world: World,
+        gameWorld: import('../../GameWorld').GameWorld,
     ): string | null
 }
 
@@ -30,6 +31,7 @@ export abstract class BaseGameState implements GameStateHandler {
         gameState: GameStateComponent,
         config: GameStateConfig,
         world: World,
+        gameWorld: import('../../GameWorld').GameWorld,
     ): string | null
 
     protected getPlayerEntity(world: World): Entity | null {

--- a/src/systems/states/BossFightState.ts
+++ b/src/systems/states/BossFightState.ts
@@ -10,6 +10,7 @@ export class BossFightState extends BaseGameState {
         gameState: GameStateComponent,
         config: GameStateConfig,
         world: World,
+        gameWorld: import('../../GameWorld').GameWorld,
     ): string | null {
         // Initialize game start time if not set
         if (this.gameStartTime === 0) {

--- a/src/systems/states/BossPreviewState.ts
+++ b/src/systems/states/BossPreviewState.ts
@@ -1,15 +1,11 @@
 import type { GameStateConfig } from '../../config/GameStateConfig'
-import type {
-    CameraTargetComponent,
-    GameStateComponent,
-    InputComponent,
-} from '../../ecs/Component'
+import type { GameStateComponent, InputComponent } from '../../ecs/Component'
 import type { World } from '../../ecs/World'
 import { BaseGameState } from './BaseGameState'
 
 export class BossPreviewState extends BaseGameState {
     private startTime: number = 0
-    private previewDuration: number = 1.0 // 1 second as requested
+    private previewDuration: number = 1.5 // 1.5 seconds to allow smooth transition to complete
     private hasStoppedMovement: boolean = false
     private hasSetCameraTarget: boolean = false
 
@@ -17,6 +13,7 @@ export class BossPreviewState extends BaseGameState {
         gameState: GameStateComponent,
         config: GameStateConfig,
         world: World,
+        gameWorld: import('../../GameWorld').GameWorld,
     ): string | null {
         // Initialize start time on first update
         if (this.startTime === 0) {
@@ -35,9 +32,9 @@ export class BossPreviewState extends BaseGameState {
             this.hasStoppedMovement = true
         }
 
-        // Set camera to focus on boss if not already done
+        // Trigger smooth camera transition to boss preview if not already done
         if (!this.hasSetCameraTarget) {
-            this.setCameraToBoss(world)
+            gameWorld.transitionToCameraState('bossPreview', 0.6) // 0.6 second smooth transition
             this.hasSetCameraTarget = true
         }
 
@@ -46,8 +43,8 @@ export class BossPreviewState extends BaseGameState {
         const elapsedTime = currentTime - this.startTime
 
         if (elapsedTime >= this.previewDuration) {
-            // Reset camera target priority to normal before transitioning
-            this.resetCameraTarget(world)
+            // Smoothly transition camera back to player focus
+            gameWorld.transitionToCameraState('playerFocus', 0.4) // 0.4 second transition back
 
             // Reset flags for potential future use
             this.hasStoppedMovement = false
@@ -76,47 +73,6 @@ export class BossPreviewState extends BaseGameState {
                 input.hasInput = false
                 input.isPointerDown = false
             }
-        }
-    }
-
-    private setCameraToBoss(world: World): void {
-        // Find boss entity by looking for entities with boss component
-        const bossEntities = world.getEntitiesWithComponent('boss')
-
-        for (const boss of bossEntities) {
-            // Add or update camera target component with high priority
-            const existingTarget =
-                boss.getComponent<CameraTargetComponent>('cameraTarget')
-            if (existingTarget) {
-                existingTarget.priority = 100 // High priority for boss preview
-                existingTarget.targetType = 'boss'
-                existingTarget.customCameraState = 'bossPreview'
-            } else {
-                const cameraTarget: CameraTargetComponent = {
-                    type: 'cameraTarget',
-                    priority: 100, // High priority to override player camera
-                    targetType: 'boss',
-                    offset: { x: 0, y: 0, z: 0 },
-                    customCameraState: 'bossPreview',
-                }
-                boss.addComponent(cameraTarget)
-            }
-            break // Only need to set camera for the first boss found
-        }
-    }
-
-    private resetCameraTarget(world: World): void {
-        // Reset boss camera target priority to normal level
-        const bossEntities = world.getEntitiesWithComponent('boss')
-
-        for (const boss of bossEntities) {
-            const cameraTarget =
-                boss.getComponent<CameraTargetComponent>('cameraTarget')
-            if (cameraTarget) {
-                cameraTarget.priority = 50 // Normal priority (player is typically 10)
-                cameraTarget.customCameraState = undefined // Remove custom state
-            }
-            break
         }
     }
 }

--- a/src/systems/states/BossPreviewState.ts
+++ b/src/systems/states/BossPreviewState.ts
@@ -1,0 +1,122 @@
+import type { GameStateConfig } from '../../config/GameStateConfig'
+import type {
+    CameraTargetComponent,
+    GameStateComponent,
+    InputComponent,
+} from '../../ecs/Component'
+import type { World } from '../../ecs/World'
+import { BaseGameState } from './BaseGameState'
+
+export class BossPreviewState extends BaseGameState {
+    private startTime: number = 0
+    private previewDuration: number = 1.0 // 1 second as requested
+    private hasStoppedMovement: boolean = false
+    private hasSetCameraTarget: boolean = false
+
+    handle(
+        gameState: GameStateComponent,
+        config: GameStateConfig,
+        world: World,
+    ): string | null {
+        // Initialize start time on first update
+        if (this.startTime === 0) {
+            this.startTime = performance.now() / 1000
+        }
+
+        // Spawn boss if not already spawned
+        if (!gameState.bossSpawned) {
+            this.spawnBoss(world, config)
+            gameState.bossSpawned = true
+        }
+
+        // Stop player movement on first update
+        if (!this.hasStoppedMovement) {
+            this.stopPlayerMovement(world)
+            this.hasStoppedMovement = true
+        }
+
+        // Set camera to focus on boss if not already done
+        if (!this.hasSetCameraTarget) {
+            this.setCameraToBoss(world)
+            this.hasSetCameraTarget = true
+        }
+
+        // Check if preview duration has elapsed
+        const currentTime = performance.now() / 1000
+        const elapsedTime = currentTime - this.startTime
+
+        if (elapsedTime >= this.previewDuration) {
+            // Reset camera target priority to normal before transitioning
+            this.resetCameraTarget(world)
+
+            // Reset flags for potential future use
+            this.hasStoppedMovement = false
+            this.hasSetCameraTarget = false
+            this.startTime = 0
+
+            // Transition to boss fight
+            return 'bossFight'
+        }
+
+        return null // Stay in current state
+    }
+
+    private stopPlayerMovement(world: World): void {
+        // Find player entity and disable input
+        for (const entity of world.getEntitiesWithComponent('player')) {
+            const input = entity.getComponent<InputComponent>('input')
+            if (input) {
+                // Stop all movement by resetting input state
+                input.moveUp = false
+                input.moveDown = false
+                input.moveLeft = false
+                input.moveRight = false
+                input.direction.x = 0
+                input.direction.y = 0
+                input.hasInput = false
+                input.isPointerDown = false
+            }
+        }
+    }
+
+    private setCameraToBoss(world: World): void {
+        // Find boss entity by looking for entities with boss component
+        const bossEntities = world.getEntitiesWithComponent('boss')
+
+        for (const boss of bossEntities) {
+            // Add or update camera target component with high priority
+            const existingTarget =
+                boss.getComponent<CameraTargetComponent>('cameraTarget')
+            if (existingTarget) {
+                existingTarget.priority = 100 // High priority for boss preview
+                existingTarget.targetType = 'boss'
+                existingTarget.customCameraState = 'bossPreview'
+            } else {
+                const cameraTarget: CameraTargetComponent = {
+                    type: 'cameraTarget',
+                    priority: 100, // High priority to override player camera
+                    targetType: 'boss',
+                    offset: { x: 0, y: 0, z: 0 },
+                    customCameraState: 'bossPreview',
+                }
+                boss.addComponent(cameraTarget)
+            }
+            break // Only need to set camera for the first boss found
+        }
+    }
+
+    private resetCameraTarget(world: World): void {
+        // Reset boss camera target priority to normal level
+        const bossEntities = world.getEntitiesWithComponent('boss')
+
+        for (const boss of bossEntities) {
+            const cameraTarget =
+                boss.getComponent<CameraTargetComponent>('cameraTarget')
+            if (cameraTarget) {
+                cameraTarget.priority = 50 // Normal priority (player is typically 10)
+                cameraTarget.customCameraState = undefined // Remove custom state
+            }
+            break
+        }
+    }
+}

--- a/src/systems/states/InitialWaveState.ts
+++ b/src/systems/states/InitialWaveState.ts
@@ -10,6 +10,7 @@ export class InitialWaveState extends BaseGameState {
         gameState: GameStateComponent,
         config: GameStateConfig,
         world: World,
+        gameWorld: import('../../GameWorld').GameWorld,
     ): string | null {
         const initialWaveConfig = config.initialWave
 

--- a/src/systems/states/NewShipOfferState.ts
+++ b/src/systems/states/NewShipOfferState.ts
@@ -1,7 +1,15 @@
+import type { GameStateConfig } from '../../config/GameStateConfig'
+import type { GameStateComponent } from '../../ecs/Component'
+import type { World } from '../../ecs/World'
 import { BaseGameState } from './BaseGameState'
 
 export class NewShipOfferState extends BaseGameState {
-    handle(): string | null {
+    handle(
+        gameState: GameStateComponent,
+        config: GameStateConfig,
+        world: World,
+        gameWorld: import('../../GameWorld').GameWorld,
+    ): string | null {
         // This state is primarily handled by the NewShipOfferUISystem
         // The UI system will call restart methods when the user clicks "Get it"
 

--- a/src/systems/states/Wave1State.ts
+++ b/src/systems/states/Wave1State.ts
@@ -10,6 +10,7 @@ export class Wave1State extends BaseGameState {
         gameState: GameStateComponent,
         config: GameStateConfig,
         world: World,
+        gameWorld: import('../../GameWorld').GameWorld,
     ): string | null {
         const waveConfig = config.wave1
 

--- a/src/systems/states/Wave2State.ts
+++ b/src/systems/states/Wave2State.ts
@@ -10,6 +10,7 @@ export class Wave2State extends BaseGameState {
         gameState: GameStateComponent,
         config: GameStateConfig,
         world: World,
+        gameWorld: import('../../GameWorld').GameWorld,
     ): string | null {
         const waveConfig = config.wave2
 

--- a/src/systems/states/Wave2State.ts
+++ b/src/systems/states/Wave2State.ts
@@ -33,7 +33,7 @@ export class Wave2State extends BaseGameState {
             gameState.wave2EnemiesSpawned === waveConfig.enemyCount &&
             aliveEnemies.length === 0
         ) {
-            return 'bossFight'
+            return 'bossPreview'
         }
 
         return null // Stay in current state

--- a/src/systems/states/index.ts
+++ b/src/systems/states/index.ts
@@ -1,5 +1,6 @@
 export * from './BaseGameState'
 export * from './BossFightState'
+export * from './BossPreviewState'
 export * from './InitialWaveState'
 export * from './NewShipOfferState'
 export * from './Wave1State'


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Add `BossPreview` state to introduce a cinematic reveal of the boss before the fight.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This new state, triggered after Wave 2, halts player movement and focuses the camera on the boss for 1 second, providing a dramatic introduction before transitioning to the `BossFight` state.

---
<a href="https://cursor.com/background-agent?bcId=bc-70b09926-b05e-4fa3-a615-c4974d259e9c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-70b09926-b05e-4fa3-a615-c4974d259e9c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>